### PR TITLE
refactor: avoid relying on cache + simplify

### DIFF
--- a/src/commands/createMatch.ts
+++ b/src/commands/createMatch.ts
@@ -1,6 +1,6 @@
 import { ApplyOptions } from '@sapphire/decorators';
 import { Command } from '@sapphire/framework';
-import type { VoiceChannel } from 'discord.js';
+import type { GuildMember, TextChannel, VoiceChannel } from 'discord.js';
 import { GameMatch } from '../lib/game/match';
 
 @ApplyOptions<Command.Options>({
@@ -36,10 +36,10 @@ export class CreateMatchCommand extends Command {
 	}
 
 	public async chatInputRun(interaction: Command.ChatInputInteraction) {
-		const guildMember = interaction.guild?.members.cache.get(interaction.user.id)!;
-		const voiceChannel = this.container.client.channels.cache.get(guildMember.voice.channelId!)! as VoiceChannel;
+		const guildMember = interaction.member as GuildMember;
+		const voiceChannel = guildMember.voice.channel as VoiceChannel;
 
-		const gameMatch = new GameMatch(interaction.channelId, voiceChannel, {
+		const gameMatch = new GameMatch(interaction.channel as TextChannel, voiceChannel, {
 			matchRounds: interaction.options.getNumber('rounds')!,
 			roundsDuration: interaction.options.getNumber('round_duration')!,
 			difficulty: interaction.options.getString('difficulty')!

--- a/src/lib/game/themes.ts
+++ b/src/lib/game/themes.ts
@@ -18,9 +18,7 @@ export class Themes {
 	private anilist: Anilist = new Anilist();
 	private matchThemesPool: Collection<number, ThemesPoolEntry> = new Collection();
 
-	constructor(private difficulty: MatchDifficulty, private matchRounds: number) {
-		this.difficulty = difficulty;
-	}
+	constructor(private difficulty: MatchDifficulty, private matchRounds: number) {}
 
 	public async populateThemesPoolByDifficulty() {
 		switch (this.difficulty) {

--- a/src/preconditions/InVoiceChannel.ts
+++ b/src/preconditions/InVoiceChannel.ts
@@ -1,14 +1,15 @@
 import { Precondition } from '@sapphire/framework';
-import type { CommandInteraction, Guild } from 'discord.js';
+import type { CommandInteraction, GuildMember } from 'discord.js';
 
 export class InVoiceChannelPrecondition extends Precondition {
 	public override async chatInputRun(interaction: CommandInteraction) {
-		return this.checkIfUserIsInVoiceChannel(interaction.guild!, interaction.user.id);
+		return this.checkIfUserIsInVoiceChannel(interaction.member as GuildMember);
 	}
 
-	private checkIfUserIsInVoiceChannel(guild: Guild, userId: string) {
-		const guildMember = guild.members.cache.get(userId)!;
-		return guildMember.voice.channel ? this.ok() : this.error({ message: 'You must be in a voice channel to create a match!' });
+	private checkIfUserIsInVoiceChannel(guildMember: GuildMember) {
+		return guildMember.voice.channel && guildMember.voice.channel.type === 'GUILD_VOICE'
+			? this.ok()
+			: this.error({ message: 'You must be in a voice channel to create a match!' });
 	}
 }
 


### PR DESCRIPTION
This PR does a few things:

- Simplifies usages of `interaction.guild?.members.cache.get(interaction.user.id)!` to just `interaction.member` (and same with channels)
- Makes sure in the `InVoiceChannelPrecondition` that the user is actually in a voice channel- currently the user can be in a stage channel too.
- Passes the whole voice channel to the game structure instead of just the ID- currently, you're turning the channel into an ID and then, in `startMatch`, right back into a channel
- Removing assignments in constructors- when you write something like `constructor(public matchChannelId: string, ...)` with the visibility modifier, `matchChannelId` will automatically be assigned to `this.matchChannelId`