### PR TITLE
refactor(matchThemesPool): use arrays

### DIFF
--- a/src/lib/game/match.ts
+++ b/src/lib/game/match.ts
@@ -49,7 +49,7 @@ export class GameMatch {
 		matchChannel.send(`Populated anime themes pool for match **${match.id}**...`);
 
 		while (this.gameOptions.matchRounds >= this.currentMatchRound) {
-			const roundThemeEntry = matchThemesPool.get(this.currentMatchRound);
+			const roundThemeEntry = matchThemesPool[this.currentMatchRound - 1];
 			if (!roundThemeEntry) throw new Error(`No theme found for round ${this.currentMatchRound}`);
 
 			await this.startRound(match.id, matchChannel, roundThemeEntry);

--- a/src/lib/game/themes.ts
+++ b/src/lib/game/themes.ts
@@ -15,8 +15,8 @@ export interface ThemesPoolEntry {
 }
 
 export class Themes {
-	private anilist: Anilist = new Anilist();
-	private matchThemesPool: Collection<number, ThemesPoolEntry> = new Collection();
+	private anilist = new Anilist();
+	private matchThemesPool: ThemesPoolEntry[] = [];
 
 	constructor(private difficulty: MatchDifficulty, private matchRounds: number) {
 		this.difficulty = difficulty;
@@ -25,7 +25,7 @@ export class Themes {
 	public async populateThemesPoolByDifficulty() {
 		switch (this.difficulty) {
 			case MatchDifficulty.EASY: {
-				for (let i = 0; i < this.matchRounds; ) {
+				while (this.matchThemesPool.length < this.matchRounds) {
 					const page = pickNumberBetween(1, 4);
 					const popularAnimes = await this.anilist.searchEntry.anime(
 						undefined,
@@ -54,8 +54,7 @@ export class Themes {
 					if (isThemeAlreadyOnPool) continue;
 					console.log(`${themeAudioUrl} - not on pool`);
 
-					const matchThemePoolEntryId = this.matchThemesPool.size + 1;
-					this.matchThemesPool.set(matchThemePoolEntryId, {
+					this.matchThemesPool.push({
 						id: selectedAnimeData.id,
 						malId: selectedAnimeData.idMal,
 						title: selectedAnimeData.title.english,
@@ -63,8 +62,6 @@ export class Themes {
 						coverImage: selectedAnimeData.coverImage.large,
 						themeAudioUrl: themeAudioUrl
 					});
-
-					i++; // We only gonna increment i if we successfully added a theme to the pool.
 				}
 
 				return this.matchThemesPool;


### PR DESCRIPTION
The point of maps/collections is largely to index values with arbitrary values instead of ordered numbers (what an array does). However, you're making the index ordered numbers anyways, so it would be simpler and more efficient to just use arrays.

Also removed `: Anilist` from `private anilist: Anilist = new Anilist();` because typescript can infer that, and simplified the for loop in `populateThemesPoolByDifficulty`.