### PR TITLE
refactor(match): simplify promise usage

### DIFF
--- a/src/lib/game/match.ts
+++ b/src/lib/game/match.ts
@@ -4,6 +4,7 @@ import { fetch, FetchResultTypes } from '@sapphire/fetch';
 import { container } from '@sapphire/framework';
 import { Formatters, TextChannel, VoiceChannel } from 'discord.js';
 import { Readable } from 'stream';
+import { setTimeout } from 'timers/promises';
 
 import { Themes, ThemesPoolEntry } from './themes';
 
@@ -116,24 +117,19 @@ export class GameMatch {
 		return matchWinner;
 	}
 
-	private playThemeOnVoiceChannel(connection: VoiceConnection, themeAudioUrl: string) {
-		return new Promise<void>(async (resolve) => {
-			const player = createAudioPlayer();
-			player.on('error', (error) => console.error(error));
-			connection.on('error', (error) => console.error(error));
+	private async playThemeOnVoiceChannel(connection: VoiceConnection, themeAudioUrl: string) {
+		const player = createAudioPlayer();
+		player.on('error', (error) => console.error(error));
+		connection.on('error', (error) => console.error(error));
 
-			const playerSubscription = connection.subscribe(player)!;
+		const playerSubscription = connection.subscribe(player)!;
 
-			const themeAudioBuffer = await fetch(themeAudioUrl, FetchResultTypes.Buffer);
-			const themeAudioResource = createAudioResource(Readable.from(themeAudioBuffer));
-			player.play(themeAudioResource);
+		const themeAudioBuffer = await fetch(themeAudioUrl, FetchResultTypes.Buffer);
+		const themeAudioResource = createAudioResource(Readable.from(themeAudioBuffer));
+		player.play(themeAudioResource);
 
-			setTimeout(() => {
-				player.stop();
-				playerSubscription.unsubscribe();
-
-				resolve();
-			}, this.gameOptions.roundsDuration * 1000);
-		});
+		await setTimeout(this.gameOptions.roundsDuration * 1000);
+		player.stop();
+		playerSubscription.unsubscribe();
 	}
 }


### PR DESCRIPTION
You can make use of the promisified node timers API to get rid of awkward `new Promise` usage.