### PR TITLE
refactor(sendAnswer): make Anilist statically available

### DIFF
--- a/src/commands/sendAnswer.ts
+++ b/src/commands/sendAnswer.ts
@@ -10,6 +10,8 @@ import { truncate } from '../lib/utils/utils';
 	preconditions: ['InVoiceChannel']
 })
 export class SendAnswerCommand extends Command {
+	private readonly anilist = new Anilist();
+
 	public override registerApplicationCommands(registry: Command.Registry) {
 		registry.registerChatInputCommand((builder) =>
 			builder
@@ -94,8 +96,7 @@ export class SendAnswerCommand extends Command {
 			`https://api.jikan.moe/v4/anime?q=${focusedOption.value}&limit=10`,
 			FetchResultTypes.JSON
 		); */
-		const anilist = new Anilist();
-		const anilistSearchResult = await anilist.searchEntry.anime(focusedOption.value, {}, 1, 10);
+		const anilistSearchResult = await this.anilist.searchEntry.anime(focusedOption.value, {}, 1, 10);
 
 		return interaction.respond(
 			anilistSearchResult.media.map((anime) => {


### PR DESCRIPTION
This PR creates a reusable `Anilist` class in the command scope so that it doesn't have to be reconstructed for every autocomplete interaction. If you want to take it a step further, you could do:

```ts
private readonly anilist = lazy(() => new Anilist());
```

using the `lazy` function from `@sapphire/utilities`, but I don't think that's necessary.